### PR TITLE
ci: upgrade github workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.10.0
-        uses: actions/setup-node@v3
+      - name: Use Node.js 22.0.0
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 22.0.0
       - run: npm ci
       - run: npm run ci

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 22.0.0
+      - name: npm run ci
         uses: actions/setup-node@v4
         with:
           node-version: 22.0.0


### PR DESCRIPTION
The node version used in the github workflow should match the version used everywhere else.
Also, bump up the versions of the github actions to latest.